### PR TITLE
Feature/65 csv stream endpoint

### DIFF
--- a/backend/api/v1/v1_categories/serializers.py
+++ b/backend/api/v1/v1_categories/serializers.py
@@ -7,6 +7,18 @@ from api.v1.v1_data.models import FormData, Answers
 from utils.functions import update_date_time_format, get_answer_value
 
 
+class ListCsvDataAnswerSerializer(serializers.ModelSerializer):
+    value = serializers.SerializerMethodField()
+
+    @extend_schema_field(OpenApiTypes.ANY)
+    def get_value(self, instance: Answers):
+        return get_answer_value(instance, toString=True)
+
+    class Meta:
+        model = Answers
+        fields = ["question", "value"]
+
+
 class ListRawDataAnswerSerializer(serializers.ModelSerializer):
     question = serializers.SerializerMethodField()
     value = serializers.SerializerMethodField()

--- a/backend/api/v1/v1_categories/urls.py
+++ b/backend/api/v1/v1_categories/urls.py
@@ -3,6 +3,7 @@ from api.v1.v1_categories.views import (
     get_data_with_category,
     get_raw_data_point,
     get_power_bi_data,
+    get_raw_csv_data,
 )
 
 urlpatterns = [
@@ -12,4 +13,5 @@ urlpatterns = [
     ),
     re_path(r"^(?P<version>(v1))/raw-data/(?P<form_id>[0-9]+)", get_raw_data_point),
     re_path(r"^(?P<version>(v1))/power-bi/(?P<form_id>[0-9]+)", get_power_bi_data),
+    re_path(r"^(?P<version>(v1))/raw-data-csv/(?P<form_id>[0-9]+)", get_raw_csv_data),
 ]

--- a/backend/api/v1/v1_categories/views.py
+++ b/backend/api/v1/v1_categories/views.py
@@ -1,3 +1,5 @@
+import pandas as pd
+from io import StringIO
 from django.http import Http404
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
@@ -5,18 +7,21 @@ from drf_spectacular.utils import (
     inline_serializer,
     OpenApiParameter,
 )
+from django.http import HttpResponse
 from rest_framework import serializers, status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from utils.custom_serializer_fields import validate_serializers_message
 from utils.custom_pagination import Pagination
 
-from api.v1.v1_categories.functions import get_category_results
+from api.v1.v1_categories.functions import get_category_results, get_category
 from api.v1.v1_categories.models import DataCategory
 from api.v1.v1_data.models import FormData, Answers
+from api.v1.v1_forms.models import Questions
 from api.v1.v1_categories.serializers import (
     ListRawDataSerializer,
     ListRawDataAnswerSerializer,
+    ListCsvDataAnswerSerializer,
 )
 
 from api.v1.v1_data.functions import get_cache, create_cache
@@ -185,3 +190,66 @@ def get_power_bi_data(request, version, form_id):
         data,
         status=status.HTTP_200_OK,
     )
+
+
+def generate_data(instances):
+    for instance in instances:
+        data = ListRawDataSerializer(instance=instance).data
+        answers = Answers.objects.filter(data_id=data["id"]).all()
+        answers = ListCsvDataAnswerSerializer(instance=answers, many=True).data
+        data.update({a["question"]: a["value"] for a in answers})
+        categories = DataCategory.objects.filter(data_id=data["id"]).all()
+        if categories:
+            for c in categories:
+                category = get_category(c.options)
+                if category:
+                    data.update({c.name: category})
+        yield data
+
+
+@extend_schema(
+    description="""
+    Get csv datapoints along with JMP data
+    """,
+    parameters=[
+        OpenApiParameter(
+            name="cache",
+            default="test",
+            required=False,
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.QUERY,
+        ),
+    ],
+    tags=["Data Categories"],
+    summary="Get csv datapoints along with JMP data",
+)
+@api_view(["GET"])
+# @permission_classes([IsAuthenticated])
+def get_raw_csv_data(request, version, form_id):
+    cache_name = request.GET.get("cache")
+    if cache_name:
+        cache_name = f"power_bi-csv-{cache_name}"
+        cache_data = get_cache(cache_name)
+        if cache_data:
+            response = HttpResponse(cache_data, content_type="text/csv")
+            response["Content-Disposition"] = 'attachment; filename="data.csv"'
+            return response
+    instances = FormData.objects.filter(form_id=form_id).order_by("-created").all()
+    data = generate_data(instances)
+    df = pd.DataFrame(data)
+    questions = Questions.objects.filter(form_id=form_id).all()
+    column_names = {}
+    for question in questions:
+        if question.id not in list(df):
+            df[f"{question.id}|{question.name}"] = ""
+        else:
+            column_names.update({question.id: f"{question.id}|{question.name}"})
+    df = df.rename(columns=column_names)
+    csv_data = StringIO()
+    df.to_csv(csv_data, sep=",", index=False)
+    csv_text = csv_data.getvalue()
+    if cache_name:
+        create_cache(cache_name, csv_text)
+    response = HttpResponse(csv_text, content_type="text/csv")
+    response["Content-Disposition"] = 'attachment; filename="data.csv"'
+    return response


### PR DESCRIPTION
Introduce `get_raw_csv_data()` with yield for efficient retrieval of raw CSV data from Power BI

The main changes include:

- The creation of a new view function, `get_raw_csv_data()`, which takes the same parameters as the original `get_power_bi_data()` function.
- The function fetches the necessary data from the database and constructs a pandas `DataFrame` using the desired data items.
- The DataFrame is then converted to raw CSV text using `pandas.to_csv()` method.
- Finally, an HTTP response is created with the CSV text as the content, and appropriate headers are set to prompt the user to download the CSV file.

By introducing this new function, we provide a direct and efficient way to retrieve the raw CSV data without the additional processing steps. This can be particularly useful in scenarios where data transformation and caching are not required, and only the raw CSV representation is needed.
